### PR TITLE
Always use type keyword in enum schemas

### DIFF
--- a/src/JsonSchemaMapper/JsonSchemaMapper.cs
+++ b/src/JsonSchemaMapper/JsonSchemaMapper.cs
@@ -330,23 +330,15 @@ internal
                 }
                 else if (type.IsEnum)
                 {
-                    if (TryGetStringEnumConverterValues(typeInfo, effectiveConverter, out JsonArray? values))
+                    if (TryGetStringEnumConverterValues(typeInfo, effectiveConverter, out enumValues))
                     {
-                        if (values is null)
-                        {
-                            // enum declared with the flags attribute -- do not surface enum values in the JSON schema.
-                            schemaType = JsonSchemaType.String;
-                        }
-                        else
-                        {
-                            if (isNullableOfTElement)
-                            {
-                                // We're generating the schema for a nullable
-                                // enum type. Append null to the "enum" array.
-                                values.Add(null);
-                            }
+                        schemaType = JsonSchemaType.String;
 
-                            enumValues = values;
+                        if (enumValues != null && isNullableOfTElement)
+                        {
+                            // We're generating the schema for a nullable
+                            // enum type. Append null to the "enum" array.
+                            enumValues.Add(null);
                         }
                     }
                     else

--- a/tests/JsonSchemaMapper.Tests/TestMethods.cs
+++ b/tests/JsonSchemaMapper.Tests/TestMethods.cs
@@ -75,7 +75,7 @@ internal static class TestMethods
                     "x2": { "type": "integer" },
                     "x3": { "type": ["string", "null"], "default": null },
                     "x4": { "type": ["integer", "null"], "default" : 42 },
-                    "x5": { "enum": ["A", "B", "C"], "default" : "A" },
+                    "x5": { "type": "string", "enum": ["A", "B", "C"], "default" : "A" },
                     "x6": {
                         "type": ["object","null"],
                         "default" : null,
@@ -104,7 +104,7 @@ internal static class TestMethods
                     "x2": { "description": "x2 description", "type": "integer" },
                     "x3": { "description": "x3 description", "type": ["string", "null"], "default": null },
                     "x4": { "description": "x4 description", "type": ["integer", "null"], "default": 42 },
-                    "x5": { "description": "x5 description", "enum": ["A", "B", "C"], "default": "A" },
+                    "x5": { "description": "x5 description", "type": "string", "enum": ["A", "B", "C"], "default": "A" },
                     "x6": {
                         "description": "x6 description",
                         "type": ["object","null"],

--- a/tests/JsonSchemaMapper.Tests/TestTypes.cs
+++ b/tests/JsonSchemaMapper.Tests/TestTypes.cs
@@ -84,7 +84,7 @@ internal static partial class TestTypes
 
         // Enum types
         yield return new TestData<IntEnum>(IntEnum.A, ExpectedJsonSchema: """{"type":"integer"}""");
-        yield return new TestData<StringEnum>(StringEnum.A);
+        yield return new TestData<StringEnum>(StringEnum.A, ExpectedJsonSchema: """{"type": "string", "enum": ["A","B","C"]}""");
         yield return new TestData<FlagsStringEnum>(FlagsStringEnum.A, ExpectedJsonSchema: """{"type":"string"}""");
 
         // Nullable<T> types
@@ -94,7 +94,7 @@ internal static partial class TestTypes
         yield return new TestData<Guid?>(Guid.Empty, AdditionalValues: [null], ExpectedJsonSchema: """{"type":["string","null"],"format":"uuid"}""");
         yield return new TestData<JsonElement?>(JsonDocument.Parse("{}").RootElement, AdditionalValues: [null], ExpectedJsonSchema: "{}");
         yield return new TestData<IntEnum?>(IntEnum.A, AdditionalValues: [null], ExpectedJsonSchema: """{"type":["integer","null"]}""");
-        yield return new TestData<StringEnum?>(StringEnum.A, AdditionalValues: [null], ExpectedJsonSchema: """{"enum":["A","B","C",null]}""");
+        yield return new TestData<StringEnum?>(StringEnum.A, AdditionalValues: [null], ExpectedJsonSchema: """{"type":["string","null"],"enum":["A","B","C",null]}""");
         yield return new TestData<SimpleRecordStruct?>(
             new(1, "two", true, 3.14), 
             AdditionalValues: [null],
@@ -183,12 +183,12 @@ internal static partial class TestTypes
                 "X2": { "type": "string" },
                 "X3": { "type": "boolean" },
                 "X4": { "type": "number" },
-                "X5": { "enum": ["A", "B", "C"], "description": "required string enum" },
+                "X5": { "type": "string", "enum": ["A", "B", "C"], "description": "required string enum" },
                 "Y1": { "type": "integer", "description": "optional integer", "default": 42 },
                 "Y2": { "type": "string", "default": "str" },
                 "Y3": { "type": "boolean", "default": true },
                 "Y4": { "type": "number", "default": 0 },
-                "Y5": { "enum": ["A", "B", "C"], "description": "optional string enum", "default": "A" }
+                "Y5": { "type": "string", "enum": ["A", "B", "C"], "description": "optional string enum", "default": "A" }
               },
               "required": ["X1", "X2", "X3", "X4", "X5"]
             }
@@ -331,9 +331,9 @@ internal static partial class TestTypes
                 "type": "object",
                 "properties": {
                     "IntEnum": { "type": "integer" },
-                    "StringEnum": { "enum": [ "A", "B", "C" ] },
-                    "IntEnumUsingStringConverter": { "enum": [ "A", "B", "C" ] },
-                    "NullableIntEnumUsingStringConverter": { "enum": [ "A", "B", "C", null ] },
+                    "StringEnum": { "type": "string", "enum": [ "A", "B", "C" ] },
+                    "IntEnumUsingStringConverter": { "type": "string", "enum": [ "A", "B", "C" ] },
+                    "NullableIntEnumUsingStringConverter": { "type": ["string", "null"], "enum": [ "A", "B", "C", null ] },
                     "StringEnumUsingIntConverter": { "type": "integer" },
                     "NullableStringEnumUsingIntConverter": { "type": [ "integer", "null" ] }
                 }
@@ -466,12 +466,12 @@ internal static partial class TestTypes
                     "X2": {"type":"integer", "default": 42 },
                     "X3": {"type":"boolean", "default": true },
                     "X4": {"type":"number", "default": 0 },
-                    "X5": {"enum":["A","B","C"], "default": "A" },
+                    "X5": {"type":"string", "enum":["A","B","C"], "default": "A" },
                     "X6": {"type":["string","null"], "default": "str" },
                     "X7": {"type":["integer","null"], "default": 42 },
                     "X8": {"type":["boolean","null"], "default": true },
                     "X9": {"type":["number","null"], "default": 0 },
-                    "X10": {"enum":["A","B","C", null], "default": "A" }
+                    "X10": {"type":["string","null"], "enum":["A","B","C", null], "default": "A" }
                 }
             }
             """);


### PR DESCRIPTION
Following feedback from https://github.com/microsoft/semantic-kernel/pull/5998#discussion_r1580682282 I'm changing the generated schema for enum types to always include the `type` keyword. Even though this is redundant for the case of `enum` schemas, this was reported to create problems when used with Gemini APIs.

cc @stephentoub @captainsafia @SergeyMenshykh @Krzysztof318