### PR TITLE
add notes on schema generation strategies

### DIFF
--- a/src/JsonSchemaMapper/JsonSchemaMapper.cs
+++ b/src/JsonSchemaMapper/JsonSchemaMapper.cs
@@ -45,7 +45,7 @@ internal
     {
         if (options is null)
         {
-           ThrowHelpers.ThrowArgumentNullException(nameof(options));
+            ThrowHelpers.ThrowArgumentNullException(nameof(options));
         }
 
         if (type is null)
@@ -706,6 +706,7 @@ internal
 
         if (format is not null)
         {
+            // It's important to note that `format` doesn't validate by default
             schema.Add(FormatPropertyName, format);
         }
 

--- a/tests/JsonSchemaMapper.Tests/Helpers.cs
+++ b/tests/JsonSchemaMapper.Tests/Helpers.cs
@@ -70,7 +70,11 @@ internal static partial class Helpers
     private static EvaluationResults EvaluateSchemaCore(JsonNode schema, JsonNode? instance)
     {
         JsonSchema jsonSchema = JsonSerializer.Deserialize(schema, Context.Default.JsonSchema)!;
-        EvaluationOptions options = new() { OutputFormat = OutputFormat.List };
+        EvaluationOptions options = new()
+        {
+            OutputFormat = OutputFormat.List,
+            RequireFormatValidation = true // format does not validate by default
+        };
         return jsonSchema.Evaluate(instance, options);
     }
 


### PR DESCRIPTION
I've added a bunch of notes regarding the decisions made for this POC.  Mostly they boil down to:

1. `format` isn't a validating keyword by default.  For the purposes of the tests, they can be treated as such in my lib by setting `RequireFormatValidation = true`.  Other validators might have similar settings, but they'd be opt-in.
2. It's considered bad practice to `$ref` directly into the schema structure.  It's recommended to extract common subschemas to a `$defs` keyword.
3. The `true` schema is preferred over the empty schema `{}` (especially as a subschema for `additionalProperties`, which historically has accepted booleans even before booleans were valid schemas).

There are a few other more targeted notes and corrections as well.

I don't intend for this PR to merge.  It's just a vehicle for notes.