### PR TITLE
Backport https://github.com/dotnet/runtime/pull/108764 to this repo.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,6 @@ jobs:
     - name: Setup .NET
       uses: actions/setup-dotnet@v3
       with:
-        dotnet-version: 9.0.100-preview.6.24328.19
+        dotnet-version: 9.0.100-rc.2.24474.11
     - name: Build & Test
       run: make

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -8,9 +8,9 @@
   <ItemGroup>
     <!-- Source dependencies -->
     <PackageVersion Include="StyleCop.Analyzers" Version="1.1.118" />
-    <PackageVersion Include="System.Text.Json" Version="8.0.4" />
+    <PackageVersion Include="System.Text.Json" Version="8.0.5" />
     <PackageVersion Include="PolySharp" Version="1.14.0" />
-    <PackageVersion Include="MinVer" Version="5.0.0" />
+    <PackageVersion Include="MinVer" Version="6.0.0" />
     <!-- Testing dependencies -->
     <PackageVersion Include="xunit" Version="2.9.0" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.2" />

--- a/src/JsonSchemaMapper/JsonSchemaGenerationContext.cs
+++ b/src/JsonSchemaMapper/JsonSchemaGenerationContext.cs
@@ -19,19 +19,30 @@ internal
 #endif
     readonly struct JsonSchemaGenerationContext
 {
+    internal readonly string[] _path;
+
     internal JsonSchemaGenerationContext(
         JsonTypeInfo typeInfo,
+        JsonTypeInfo? baseTypeInfo,
         Type? declaringType,
         JsonPropertyInfo? propertyInfo,
         ParameterInfo? parameterInfo,
-        ICustomAttributeProvider? propertyAttributeProvider)
+        ICustomAttributeProvider? propertyAttributeProvider,
+        string[] path)
     {
         TypeInfo = typeInfo;
         DeclaringType = declaringType;
+        BaseTypeInfo = baseTypeInfo;
         PropertyInfo = propertyInfo;
         ParameterInfo = parameterInfo;
         PropertyAttributeProvider = propertyAttributeProvider;
+        _path = path;
     }
+
+    /// <summary>
+    /// The path to the schema document currently being generated.
+    /// </summary>
+    public ReadOnlySpan<string> Path => _path;
 
     /// <summary>
     /// The <see cref="JsonTypeInfo"/> for the type being processed.
@@ -42,6 +53,11 @@ internal
     /// The declaring type of the property or parameter being processed.
     /// </summary>
     public Type? DeclaringType { get; }
+
+    /// <summary>
+    /// The type info for the polymorphic base type if generated as a derived type.
+    /// </summary>
+    public JsonTypeInfo? BaseTypeInfo { get; }
 
     /// <summary>
     /// The <see cref="JsonPropertyInfo"/> if the schema is being generated for a property.

--- a/src/JsonSchemaMapper/JsonSchemaMapper.STJv9.cs
+++ b/src/JsonSchemaMapper/JsonSchemaMapper.STJv9.cs
@@ -112,10 +112,12 @@ internal
     {
         JsonSchemaGenerationContext mapperCtx = new(
             ctx.TypeInfo,
-            ctx.TypeInfo.Type,
+            ctx.BaseTypeInfo,
+            ctx.PropertyInfo?.DeclaringType,
             ctx.PropertyInfo,
             (ParameterInfo?)ctx.PropertyInfo?.AssociatedParameter?.AttributeProvider,
-            ctx.PropertyInfo?.AttributeProvider);
+            ctx.PropertyInfo?.AttributeProvider,
+            ctx.Path.ToArray());
 
         if (configuration.IncludeTypeInEnums)
         {

--- a/tests/JsonSchemaMapper.Tests/Helpers.cs
+++ b/tests/JsonSchemaMapper.Tests/Helpers.cs
@@ -13,7 +13,7 @@ internal static partial class Helpers
     {
         // If an expected schema is provided, use that. Otherwise, generate a schema from the type.
         JsonNode? expectedJsonSchemaNode = expectedJsonSchema != null
-            ? JsonNode.Parse(expectedJsonSchema)
+            ? JsonNode.Parse(expectedJsonSchema, documentOptions: new() { CommentHandling = JsonCommentHandling.Skip })
             : JsonSerializer.SerializeToNode(new JsonSchemaBuilder().FromType(type), Context.Default.JsonSchema);
 
         // Trim the $schema property from actual schema since it's not included by the generator.

--- a/tests/JsonSchemaMapper.Tests/JsonSchemaMapperTests.cs
+++ b/tests/JsonSchemaMapper.Tests/JsonSchemaMapperTests.cs
@@ -4,6 +4,7 @@ using System.Text.Json;
 using System.Text.Json.Nodes;
 using System.Text.Json.Serialization;
 using System.Text.Json.Serialization.Metadata;
+using System.Xml.Linq;
 using Xunit;
 
 namespace JsonSchemaMapper.Tests;
@@ -102,6 +103,15 @@ public abstract class JsonSchemaMapperTests
         JsonValue value = Assert.IsAssignableFrom<JsonValue>(schema["type"]);
         Assert.Equal(expectedType, (string)value!);
     }
+
+#if !NET9_0 // Disable until https://github.com/dotnet/runtime/pull/108764 gets backported
+    [Fact]
+    public void CanGenerateXElementSchema()
+    {
+        JsonNode schema = Options.GetJsonSchema(typeof(XElement));
+        Assert.True(schema.ToJsonString().Length < 100_000);
+    }
+#endif
 
     [Fact]
     public void TreatNullObliviousAsNonNullable_True_DoesNotImpactObjectType()


### PR DESCRIPTION
Backports the fix to https://github.com/dotnet/runtime/issues/108755 in this repo.

FYI @SergeyMenshykh @ntaylormullen. Consider updating your copies if there's a scenario where schemas can be generated for unexpected user provided types like `XElement`.